### PR TITLE
Add default value to unset environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ This enables you to specify things that vary across API calls either permanently
 
 Environment-variables are expanded first and can be used with any executable. Example `$(cat ${ENV}/token.json)`.
 
+Also it allows to specify a default value to be used in case the environment-variable doesn't hold any value, the syntax for this is `${ENVVARNAME:default_value}`.
+
 Ain uses [envparse](https://github.com/hashicorp/go-envparse) for parsing environment variables.
 
 # Executables


### PR DESCRIPTION
Similar to how it's been done in bash, this allows
to give dafault values to environment variables
that hasn't been set yet.

Test plan:
* Test the old syntax by using ${ENVVAR},
  expect to behave the same way.
* Test the new syntax by using ${ENVVAR:foobar},
  expect to use the value after the semi-colon
  if the environment variable has not been set.

Congrats for such a cool project, Ain is just what I have been looking for. 💝
