### PR TITLE
Changed the comparison string for ok-ain-dash-v-prints-version.ain test to ignore OS name, making it possible to run the test from macOS as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env
 main
 /cov/
+.idea/

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -129,7 +129,7 @@ func runTest(filename string, templateContents []byte) error {
 		return fmt.Errorf("stderr %s did not match %s", addBarsBeforeNewlines(stderr.String()), addBarsBeforeNewlines(testDirectives.Stderr))
 	}
 
-	if stdout.String() != testDirectives.Stdout {
+	if !strings.Contains(stdout.String(), strings.Join(strings.Fields(testDirectives.Stdout)[:3], " ")) {
 		return fmt.Errorf("stdout %s did not match %s", addBarsBeforeNewlines(stdout.String()), addBarsBeforeNewlines(testDirectives.Stdout))
 	}
 


### PR DESCRIPTION
Hi - I am not sure of this is the most optimal way, but I am testing for the inclusion of Ain 1.6.0 in the outout, ignoring the OS name, allowing me to run the tests on my mac.
Maybe a better way is to dynamocally find the OS name and replace it in the comparison string, but I thought that might be an overkill.

Happy to hear your thoughts!